### PR TITLE
[#173352060] Added CDN endpoint delivery rules

### DIFF
--- a/azurerm_cdn_endpoint/main.tf
+++ b/azurerm_cdn_endpoint/main.tf
@@ -23,6 +23,34 @@ resource "azurerm_cdn_endpoint" "cdn_endpoint" {
     host_name = var.origin_host_name
   }
 
+  dynamic "global_delivery_rule" {
+    iterator = l
+    for_each = var.global_delivery_rule_cache_expiration_action
+    content {
+      cache_expiration_action {
+        behavior = l.value.behavior
+        duration = l.value.duration
+      }
+    }
+  }
+
+  dynamic "delivery_rule" {
+    iterator = l
+    for_each = var.delivery_rule_url_path_condition_cache_expiration_action
+    content {
+      name  = l.value.name
+      order = l.value.order
+      url_path_condition {
+        operator     = l.value.operator
+        match_values = l.value.match_values
+      }
+      cache_expiration_action {
+        behavior = l.value.behavior
+        duration = l.value.duration
+      }      
+    }
+  }
+
   tags = {
     environment = var.environment
   }

--- a/azurerm_cdn_endpoint/main.tf
+++ b/azurerm_cdn_endpoint/main.tf
@@ -23,30 +23,25 @@ resource "azurerm_cdn_endpoint" "cdn_endpoint" {
     host_name = var.origin_host_name
   }
 
-  dynamic "global_delivery_rule" {
-    iterator = l
-    for_each = var.global_delivery_rule_cache_expiration_action
-    content {
-      cache_expiration_action {
-        behavior = l.value.behavior
-        duration = l.value.duration
-      }
+  global_delivery_rule {
+    cache_expiration_action {
+      behavior = var.global_delivery_rule_cache_expiration_action.behavior
+      duration = var.global_delivery_rule_cache_expiration_action.duration
     }
   }
 
   dynamic "delivery_rule" {
-    iterator = l
-    for_each = var.delivery_rule_url_path_condition_cache_expiration_action
+    for_each = { for d in var.delivery_rule_url_path_condition_cache_expiration_action : d.order => d }
     content {
-      name  = l.value.name
-      order = l.value.order
+      order = delivery_rule.key
+      name  = delivery_rule.value.name
       url_path_condition {
-        operator     = l.value.operator
-        match_values = l.value.match_values
+        operator     = delivery_rule.value.operator
+        match_values = delivery_rule.value.match_values
       }
       cache_expiration_action {
-        behavior = l.value.behavior
-        duration = l.value.duration
+        behavior = delivery_rule.value.behavior
+        duration = delivery_rule.value.duration
       }      
     }
   }

--- a/azurerm_cdn_endpoint/main.tf
+++ b/azurerm_cdn_endpoint/main.tf
@@ -23,10 +23,13 @@ resource "azurerm_cdn_endpoint" "cdn_endpoint" {
     host_name = var.origin_host_name
   }
 
-  global_delivery_rule {
-    cache_expiration_action {
-      behavior = var.global_delivery_rule_cache_expiration_action.behavior
-      duration = var.global_delivery_rule_cache_expiration_action.duration
+  dynamic "global_delivery_rule" {
+    for_each = var.global_delivery_rule_cache_expiration_action == null ? [] : ["dummy"]
+    content {
+      cache_expiration_action {
+        behavior = var.global_delivery_rule_cache_expiration_action.behavior
+        duration = var.global_delivery_rule_cache_expiration_action.duration
+      }
     }
   }
 

--- a/azurerm_cdn_endpoint/vars.tf
+++ b/azurerm_cdn_endpoint/vars.tf
@@ -55,6 +55,7 @@ variable "global_delivery_rule_cache_expiration_action" {
     behavior = string
     duration = string
   })
+  default = null
 }
 
 variable "delivery_rule_url_path_condition_cache_expiration_action" {

--- a/azurerm_cdn_endpoint/vars.tf
+++ b/azurerm_cdn_endpoint/vars.tf
@@ -50,6 +50,26 @@ variable "origin_host_name" {
   type = string
 }
 
+variable "global_delivery_rule_cache_expiration_action" {
+  type = list(object({
+    behavior = string
+    duration = string
+  }))
+  default = []
+}
+
+variable "delivery_rule_url_path_condition_cache_expiration_action" {
+  type = list(object({
+    name         = string
+    order        = number
+    operator     = string
+    match_values = list(string)
+    behavior     = string
+    duration     = string
+  }))
+  default = []
+}
+
 locals {
   resource_name = "${var.global_prefix}-${var.environment_short}-cdnendpoint-${var.name}"
 }

--- a/azurerm_cdn_endpoint/vars.tf
+++ b/azurerm_cdn_endpoint/vars.tf
@@ -51,11 +51,10 @@ variable "origin_host_name" {
 }
 
 variable "global_delivery_rule_cache_expiration_action" {
-  type = list(object({
+  type = object({
     behavior = string
     duration = string
-  }))
-  default = []
+  })
 }
 
 variable "delivery_rule_url_path_condition_cache_expiration_action" {


### PR DESCRIPTION
The following changes are required to allow to add to a CDN endpoint the delivery rules required to define different cache expirations duration (TTL).

In particular, in this way it is possible to rules in the Rules engine as shown in this example:
<img width="1786" alt="Screenshot 2020-06-16 at 11 16 03" src="https://user-images.githubusercontent.com/60641726/84756318-ee045900-afc2-11ea-82df-051f74be4985.png">

**NOTE.** These changes are expected to be released with next release **v2.0.31** in order to be referenced in https://github.com/pagopa/io-infrastructure-live-new/blob/master/prod/westeurope/common/cdn/cdn_endpoint_assets/terragrunt.hcl.