### PR TITLE
reenable cbc ciphers for some 4.4.x Android clients

### DIFF
--- a/azurerm_application_gateway/main.tf
+++ b/azurerm_application_gateway/main.tf
@@ -220,7 +220,9 @@ resource "azurerm_application_gateway" "application_gateway" {
     policy_type = "Custom"
     cipher_suites = [
       "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-      "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+      "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+      "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+      "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA"
     ]
     min_protocol_version = "TLSv1_2"
   }


### PR DESCRIPTION
Unfortunately some 4.4.x clients that support TLS 1.2 do not have GCM ciphers and are unable to connect.
This will re-order the ciphers list so that we prefer GCM rather than CBC when negotiating, but still have both.