### PR TITLE
[#176863396] Function app fix error failed-to-remove-local-cache

### DIFF
--- a/azurerm_function_app/main.tf
+++ b/azurerm_function_app/main.tf
@@ -167,21 +167,3 @@ resource "azurerm_app_service_virtual_network_swift_connection" "app_service_vir
   app_service_id = azurerm_function_app.function_app.id
   subnet_id      = var.subnet_id != null ? var.subnet_id : module.subnet[0].id
 }
-
-module "application_insights_web_test" {
-  count  = var.web_test != null && var.health_check_path != null ? 1 : 0
-  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_function_app?ref=v2.1.29"
-
-  global_prefix     = var.global_prefix
-  environment       = var.environment
-  environment_short = var.environment_short
-  region            = var.region
-
-  name                    = "${var.resources_prefix.function_app}-${var.name}"
-  resource_group_name     = var.resource_group_name
-  application_insights_id = var.web_test.application_insights_id
-
-  kind    = "ping"
-  enabled = var.web_test.enabled
-  url     = "https://${azurerm_function_app.function_app.default_hostname}${var.health_check_path}"
-}

--- a/azurerm_function_app/vars.tf
+++ b/azurerm_function_app/vars.tf
@@ -154,24 +154,6 @@ variable "export_keys" {
   default = false
 }
 
-variable "health_check_path" {
-  type    = string
-  default = null
-}
-
-variable "health_check_maxpingfailures" {
-  type    = number
-  default = 10
-}
-
-variable "web_test" {
-  type = object({
-    application_insights_id = string
-    enabled                 = bool
-  })
-  default = null
-}
-
 locals {
   resource_name = "${var.global_prefix}-${var.environment_short}-${var.resources_prefix.function_app}-${var.name}"
 }


### PR DESCRIPTION
That module was causing this issue:
```
Error: Failed to remove local module cache

Terraform tried to remove
.terraform/modules/application_insights_web_test.application_insights_web_test.application_insights_web_test.application_insights_web_test.application_insights_web_test.application_insights_web_test.application_insights_web_test.application_insights_web_test.secrets_from_keyvault
in order to reinstall this module, but encountered an error: unlinkat
.terraform/modules/application_insights_web_test.application_insights_web_test.application_insights_web_test.application_insights_web_test.application_insights_web_test.application_insights_web_test.application_insights_web_test.application_insights_web_test.secrets_from_keyvault:
file name too long
```

I don't know if it's something related to the new provider 2.46.1

Hopefully we can use the module outside the function like I did with the app_service