### PR TITLE
[#IOINFRA-180] Write multiregion DNS records

### DIFF
--- a/azurerm_private_endpoint/main.tf
+++ b/azurerm_private_endpoint/main.tf
@@ -23,4 +23,11 @@ resource "azurerm_private_endpoint" "private_endpoint" {
     subresource_names              = var.private_service_connection.subresource_names
   }
 
+  dynamic "private_dns_zone_group" {
+    for_each = var.private_dns_zone_ids != null ? ["dummy"] : []
+    content {
+      name                 = "private-dns-zone-group"
+      private_dns_zone_ids = var.private_dns_zone_ids
+    }
+  }
 }

--- a/azurerm_private_endpoint/vars.tf
+++ b/azurerm_private_endpoint/vars.tf
@@ -38,3 +38,9 @@ variable "private_service_connection" {
     }
   )
 }
+
+variable "private_dns_zone_ids" {
+  type    = list(string)
+  default = null
+  description = "(Optional) Specifies the list of Private DNS Zones to write DNS records"
+}


### PR DESCRIPTION
Setting `private_dns_zone_ids` add DNS records to specified DNS zone.
If the resource is multi region, will be written all DNS records.
No more needed to write standalone DNS A records