### PR TITLE
Add private storage for fnapp and fnapp slot

### DIFF
--- a/azurerm_function_app/main.tf
+++ b/azurerm_function_app/main.tf
@@ -18,18 +18,114 @@ data "azurerm_key_vault_secret" "allowed_ips_secret" {
 }
 
 module "storage_account" {
-  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_storage_account?ref=v3.0.3"
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_storage_account?ref=optional-storage-account-advanced_threat_protection"
 
   global_prefix     = var.global_prefix
   environment       = var.environment
   environment_short = var.environment_short
   region            = var.region
 
-  name                     = "${var.resources_prefix.storage_account}${var.name}"
-  resource_group_name      = var.resource_group_name
-  account_tier             = var.storage_account_info.account_tier
-  account_replication_type = var.storage_account_info.account_replication_type
-  access_tier              = var.storage_account_info.access_tier
+  name                              = "${var.resources_prefix.storage_account}${var.name}"
+  resource_group_name               = var.resource_group_name
+  account_tier                      = var.storage_account_info.account_tier
+  account_replication_type          = var.storage_account_info.account_replication_type
+  access_tier                       = var.storage_account_info.access_tier
+  advanced_threat_protection_enable = true
+}
+
+module "storage_account_durable_function" {
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_storage_account?ref=optional-storage-account-advanced_threat_protection"
+
+  global_prefix     = var.global_prefix
+  environment       = var.environment
+  environment_short = var.environment_short
+  region            = var.region
+
+  name                              = "${var.resources_prefix.storage_account}d${var.name}"
+  resource_group_name               = var.resource_group_name
+  account_tier                      = var.storage_account_info.account_tier
+  account_replication_type          = var.storage_account_info.account_replication_type
+  access_tier                       = var.storage_account_info.access_tier
+  advanced_threat_protection_enable = false
+
+  network_rules = {
+    default_action = "Deny"
+    ip_rules       = []
+    bypass = [
+      "Logging",
+      "Metrics",
+      "AzureServices",
+    ]
+    virtual_network_subnet_ids = [
+      local.subnet_id
+    ]
+  }
+}
+
+module "storage_account_durable_function_private_endpoint_blob" {
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_private_endpoint?ref=v3.0.10"
+
+  global_prefix     = var.global_prefix
+  environment       = var.environment
+  environment_short = var.environment_short
+  region            = var.region
+
+  name                = "${module.storage_account_durable_function.resource_name}-blob-endpoint"
+  resource_group_name = var.resource_group_name
+  subnet_id           = var.storage_durable_function_private_endpoint.subnet_id
+
+  private_service_connection = {
+    name                           = "${module.storage_account_durable_function.resource_name}-blob"
+    private_connection_resource_id = module.storage_account_durable_function.id
+    is_manual_connection           = false
+    subresource_names              = ["blob"]
+  }
+
+  private_dns_zone_ids = var.storage_durable_function_private_endpoint.private_dns_zone_blob_ids
+}
+
+module "storage_account_durable_function_private_endpoint_queue" {
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_private_endpoint?ref=v3.0.10"
+
+  global_prefix     = var.global_prefix
+  environment       = var.environment
+  environment_short = var.environment_short
+  region            = var.region
+
+  name                = "${module.storage_account_durable_function.resource_name}-queue-endpoint"
+  resource_group_name = var.resource_group_name
+  subnet_id           = var.storage_durable_function_private_endpoint.subnet_id
+
+  private_service_connection = {
+    name                           = "${module.storage_account_durable_function.resource_name}-queue"
+    private_connection_resource_id = module.storage_account_durable_function.id
+    is_manual_connection           = false
+    subresource_names              = ["queue"]
+  }
+
+  private_dns_zone_ids = var.storage_durable_function_private_endpoint.private_dns_zone_queue_ids
+}
+
+module "storage_account_durable_function_private_endpoint_table" {
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_private_endpoint?ref=v3.0.10"
+
+  global_prefix     = var.global_prefix
+  environment       = var.environment
+  environment_short = var.environment_short
+  region            = var.region
+
+  name                = "${module.storage_account_durable_function.resource_name}-table-endpoint"
+  resource_group_name = var.resource_group_name
+  subnet_id           = var.storage_durable_function_private_endpoint.subnet_id
+
+  private_service_connection = {
+    name                           = "${module.storage_account_durable_function.resource_name}-table"
+    private_connection_resource_id = module.storage_account_durable_function.id
+    is_manual_connection           = false
+    subresource_names              = ["table"]
+  }
+
+  private_dns_zone_ids = var.storage_durable_function_private_endpoint.private_dns_zone_table_ids
 }
 
 module "app_service_plan" {
@@ -60,6 +156,7 @@ locals {
   allowed_subnets    = [for s in var.allowed_subnets : { ip_address = null, virtual_network_subnet_id = s }]
   allowed_ips_secret = [for ip in var.allowed_ips_secret == null ? [] : split(";", data.azurerm_key_vault_secret.allowed_ips_secret[0].value) : { ip_address = ip, virtual_network_subnet_id = null }]
   ip_restrictions    = concat(local.allowed_subnets, local.allowed_ips_secret, local.allowed_ips)
+  subnet_id          = var.subnet_id != null ? var.subnet_id : module.subnet[0].id
 }
 
 resource "azurerm_function_app" "function_app" {
@@ -104,6 +201,15 @@ resource "azurerm_function_app" "function_app" {
       WEBSITE_ADD_SITENAME_BINDINGS_IN_APPHOST_CONFIG = 1
       # default value for health_check_path, override it in var.app_settings if needed
       WEBSITE_HEALTHCHECK_MAXPINGFAILURES = var.health_check_path != null ? var.health_check_maxpingfailures : null
+      # https://docs.microsoft.com/en-us/samples/azure-samples/azure-functions-private-endpoints/connect-to-private-endpoints-with-azure-functions/
+      DURABLE_FUNCTION_STORAGE_CONNECTION_STRING = module.storage_account_durable_function.primary_connection_string
+      SLOT_TASK_HUBNAME                          = "ProductionTaskHub"
+      WEBSITE_RUN_FROM_PACKAGE                   = 1
+      WEBSITE_VNET_ROUTE_ALL                     = 1
+      WEBSITE_DNS_SERVER                         = "168.63.129.16"
+      # this app settings is required to solve the issue:
+      # https://github.com/terraform-providers/terraform-provider-azurerm/issues/10499
+      WEBSITE_CONTENTSHARE = "${local.resource_name}-content"
     },
     var.app_settings,
     module.secrets_from_keyvault.secrets_with_value
@@ -162,5 +268,5 @@ resource "azurerm_app_service_virtual_network_swift_connection" "app_service_vir
   count = var.subnet_id == null && var.virtual_network_info == null ? 0 : 1
 
   app_service_id = azurerm_function_app.function_app.id
-  subnet_id      = var.subnet_id != null ? var.subnet_id : module.subnet[0].id
+  subnet_id      = local.subnet_id
 }

--- a/azurerm_function_app/main.tf
+++ b/azurerm_function_app/main.tf
@@ -18,7 +18,7 @@ data "azurerm_key_vault_secret" "allowed_ips_secret" {
 }
 
 module "storage_account" {
-  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_storage_account?ref=optional-storage-account-advanced_threat_protection"
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_storage_account?ref=v3.0.11"
 
   global_prefix     = var.global_prefix
   environment       = var.environment
@@ -34,7 +34,7 @@ module "storage_account" {
 }
 
 module "storage_account_durable_function" {
-  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_storage_account?ref=optional-storage-account-advanced_threat_protection"
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_storage_account?ref=v3.0.11"
 
   global_prefix     = var.global_prefix
   environment       = var.environment

--- a/azurerm_function_app/outputs.tf
+++ b/azurerm_function_app/outputs.tf
@@ -35,10 +35,19 @@ output "app_service_plan_id" {
 
 output "storage_account" {
   value = {
-    name               = module.storage_account.resource_name
-    primary_access_key = module.storage_account.primary_access_key
+    name                      = module.storage_account.resource_name
+    primary_access_key        = module.storage_account.primary_access_key
+    primary_connection_string = module.storage_account.primary_connection_string
   }
+  sensitive = true
+}
 
+output "storage_account_durable_function" {
+  value = {
+    name                      = module.storage_account_durable_function.resource_name
+    primary_access_key        = module.storage_account_durable_function.primary_access_key
+    primary_connection_string = module.storage_account_durable_function.primary_connection_string
+  }
   sensitive = true
 }
 

--- a/azurerm_function_app/outputs.tf
+++ b/azurerm_function_app/outputs.tf
@@ -43,11 +43,11 @@ output "storage_account" {
 }
 
 output "storage_account_durable_function" {
-  value = {
-    name                      = module.storage_account_durable_function.resource_name
-    primary_access_key        = module.storage_account_durable_function.primary_access_key
-    primary_connection_string = module.storage_account_durable_function.primary_connection_string
-  }
+  value = var.durable_function.enable ? {
+    name                      = module.storage_account_durable_function[0].resource_name
+    primary_access_key        = module.storage_account_durable_function[0].primary_access_key
+    primary_connection_string = module.storage_account_durable_function[0].primary_connection_string
+  } : null
   sensitive = true
 }
 

--- a/azurerm_function_app/vars.tf
+++ b/azurerm_function_app/vars.tf
@@ -143,15 +143,22 @@ variable "virtual_network_info" {
   default = null
 }
 
-variable "storage_durable_function_private_endpoint" {
+variable "durable_function" {
   type = object({
-    subnet_id                  = string
+    enable                     = bool
+    private_endpoint_subnet_id = string
     private_dns_zone_blob_ids  = list(string)
     private_dns_zone_queue_ids = list(string)
     private_dns_zone_table_ids = list(string)
   })
 
-  default = null
+  default = {
+    enable                     = false
+    private_endpoint_subnet_id = "dummy"
+    private_dns_zone_blob_ids  = []
+    private_dns_zone_queue_ids = []
+    private_dns_zone_table_ids = []
+  }
 }
 
 variable "avoid_old_subnet_delete" {

--- a/azurerm_function_app/vars.tf
+++ b/azurerm_function_app/vars.tf
@@ -143,6 +143,17 @@ variable "virtual_network_info" {
   default = null
 }
 
+variable "storage_durable_function_private_endpoint" {
+  type = object({
+    subnet_id                  = string
+    private_dns_zone_blob_ids  = list(string)
+    private_dns_zone_queue_ids = list(string)
+    private_dns_zone_table_ids = list(string)
+  })
+
+  default = null
+}
+
 variable "avoid_old_subnet_delete" {
   type = bool
 

--- a/azurerm_function_app_slot/main.tf
+++ b/azurerm_function_app_slot/main.tf
@@ -84,6 +84,16 @@ resource "azurerm_function_app_slot" "function_app_slot" {
       WEBSITE_ADD_SITENAME_BINDINGS_IN_APPHOST_CONFIG = 1
       # default value for health_check_path, override it in var.app_settings if needed
       WEBSITE_HEALTHCHECK_MAXPINGFAILURES = var.health_check_path != null ? var.health_check_maxpingfailures : null
+      # https://docs.microsoft.com/en-us/samples/azure-samples/azure-functions-private-endpoints/connect-to-private-endpoints-with-azure-functions/
+      # https://github.com/Azure/Azure-Functions/issues/1349#issuecomment-747476420
+      DURABLE_FUNCTION_STORAGE_CONNECTION_STRING = var.storage_account_durable_function_connection_string
+      SLOT_TASK_HUBNAME                          = "${title(var.name)}TaskHub"
+      WEBSITE_RUN_FROM_PACKAGE                   = 1
+      WEBSITE_VNET_ROUTE_ALL                     = 1
+      WEBSITE_DNS_SERVER                         = "168.63.129.16"
+      # this app settings is required to solve the issue:
+      # https://github.com/terraform-providers/terraform-provider-azurerm/issues/10499
+      WEBSITE_CONTENTSHARE = "${var.name}-content"
     },
     var.app_settings,
     module.secrets_from_keyvault.secrets_with_value

--- a/azurerm_function_app_slot/vars.tf
+++ b/azurerm_function_app_slot/vars.tf
@@ -53,6 +53,10 @@ variable "storage_account_access_key" {
   type = string
 }
 
+variable "storage_account_durable_function_connection_string" {
+  type = string
+}
+
 variable "pre_warmed_instance_count" {
   type = number
 


### PR DESCRIPTION
```
{
  "version": "2.0",
  "logging": {
    "logLevel": {
      "default": "Trace"
    }
  },
  "extensions": {
    "http": {
      "routePrefix": ""
    },
    "durableTask": {
      "hubName": "%SLOT_TASK_HUBNAME%",
      "storageProvider": {
        "connectionStringName": "AzureWebJobsStorage" # to change with DURABLE_FUNCTION_STORAGE_CONNECTION_STRING
      },
      "tracing": {
        "traceInputsAndOutputs": false,
        "traceReplayEvents": false
      }
    }
  }
}
```

changing `connectionStringName` in host.json function app will use a private storage account to run durable functions

`AzureWebJobsStorage` -> `DURABLE_FUNCTION_STORAGE_CONNECTION_STRING`