### PR TITLE
GCM only ciphersuites

### DIFF
--- a/azurerm_application_gateway/main.tf
+++ b/azurerm_application_gateway/main.tf
@@ -228,9 +228,7 @@ resource "azurerm_application_gateway" "application_gateway" {
     policy_type = "Custom"
     cipher_suites = [
       "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-      "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-      "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-      "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA"
+      "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
     ]
     min_protocol_version = "TLSv1_2"
   }


### PR DESCRIPTION
Now that our min SDK version is 21, Android 5.0, we should have clients with full support to GCM cipher suites (and hopefully they are not bugged liked the ones on 4.4.x or 4.3.x).

This has a risk of breaking production for non-conforming devices.

Please @Undermaken or team, confirm that pre 5.0 traffic is blocked anyway because of app minimum version, which is not compiled anymore for < 5.0.

We need to schedule an apply window, where Mixpanel analytics will be watched to detect unexpected, broken TLS 1.2 implementation on 5.0+.